### PR TITLE
Lowercase 'content-type'

### DIFF
--- a/server/routes/feed/[...slug].ts
+++ b/server/routes/feed/[...slug].ts
@@ -85,7 +85,7 @@ export default defineEventHandler(async (event) => {
 		feed.items.push(item);
 	}
 
-	setResponseHeader(event, 'Content-Type', 'application/feed+json');
+	setResponseHeader(event, 'content-type', 'application/feed+json');
 
 	return feed;
 });


### PR DESCRIPTION
For Nitro compatibility in-case it doesn't normalize the header